### PR TITLE
[FIX] #82 Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ exceptiongroup==1.0.4
 iniconfig==1.1.1
 packaging==21.3
 pluggy==1.0.0
-pycodestyle==2.9.1
+pycodestyle==2.11.0
 pyparsing==3.0.9
 pyproject_hooks==1.0.0
 pytest==7.2.0


### PR DESCRIPTION
#82
flake8 6.1.0 requires pycodestyle<2.12.0,>=2.11.0, but you have pycodestyle 2.9.1 which is incompatible.