### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@ name: 'coverage'
 on:
   push:
     branches: [ "master" ]
+permissions:
+  contents: write
 jobs:
     coverage:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DarekRepos/PanTadeuszWordFinder/security/code-scanning/1](https://github.com/DarekRepos/PanTadeuszWordFinder/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/python-package.yml` to enforce least privilege for this workflow.

Best fix here (without changing behavior): set workflow-level permissions to:
- `contents: write` (required for the auto-commit step that pushes changes)
- no other scopes unless needed

This keeps existing functionality (badge/report commit) while removing reliance on repository/org defaults.  
Edit region: near the top of `.github/workflows/python-package.yml`, directly after the `on:` trigger block and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
